### PR TITLE
fixes query params on user.contacts! and user.groups!

### DIFF
--- a/lib/google_contacts_api/user.rb
+++ b/lib/google_contacts_api/user.rb
@@ -18,7 +18,7 @@ module GoogleContactsApi
     def contacts!(params = {})
       # contacts in this group
       @contacts = nil
-      contacts
+      contacts(params)
     end
 
     # Return the groups for this user and cache them.
@@ -29,7 +29,7 @@ module GoogleContactsApi
     # Return the groups for this user, retrieving them again from the server.
     def groups!(params = {})
       @groups = nil
-      groups
+      groups(params)
     end
   end
 end

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -130,6 +130,22 @@ describe "GoogleContactsApi" do
         expect(user.groups).to eq("group set")
       end
     end
+    describe ".groups!" do
+      it "should be able to get groups" do
+        expect(user).to receive(:get_groups).and_return("group set")
+        expect(user.groups!).to eq("group set")
+      end
+      it "should pass query params along to get_groups" do
+        expect(user).to receive(:get_groups).with("something" => "important").and_return("group set")
+        expect(user.groups!("something" => "important")).to eq("group set")
+      end
+      it "should reload the groups" do
+        expect(user).to receive(:get_groups).and_return("group set").twice
+        user.groups
+        groups = user.groups!
+        expect(groups).to eq("group set")
+      end
+    end
     describe ".contacts" do
       it "should be able to get contacts" do
         expect(user).to receive(:get_contacts).and_return("contact set")
@@ -146,6 +162,10 @@ describe "GoogleContactsApi" do
       it "should be able to get contacts" do
         expect(user).to receive(:get_contacts).and_return("contact set")
         expect(user.contacts!).to eq("contact set")
+      end
+      it "should pass query params along to get_contacts" do
+        expect(user).to receive(:get_contacts).with("something" => "important").and_return("contact set")
+        expect(user.contacts!("something" => "important")).to eq("contact set")
       end
       it "should reload the contacts" do
         expect(user).to receive(:get_contacts).and_return("contact set").twice


### PR DESCRIPTION
Query params were not being pushed from `user.contacts!` => `user.contacts` or `user.groups!` => `user.groups`.