### PR TITLE
Add more contact fields

### DIFF
--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -141,6 +141,8 @@ module GoogleContactsApi
       formatted = {}
       formatted[:rel] = unformatted['rel'] ? unformatted['rel'].gsub('http://schemas.google.com/g/2005#', '') : 'work'
       unformatted.delete 'rel'
+      formatted[:primary] = unformatted['primary'] ? unformatted['primary'] == 'true' : false
+      unformatted.delete 'primary'
       unformatted.each do |key, value|
         formatted[key.sub('gd$', '').underscore.to_sym] = value['$t']
       end
@@ -149,10 +151,11 @@ module GoogleContactsApi
 
     def format_email_or_phone(unformatted)
       formatted = {}
+      formatted[:primary] = unformatted['primary'] ? unformatted['primary'] == 'true' : false
+      unformatted.delete 'primary'
       unformatted.each do |key, value|
         formatted[key.underscore.to_sym] = value ? value.gsub('http://schemas.google.com/g/2005#', '') : value
       end
-      formatted[:primary] = unformatted['primary'] ? unformatted['primary'] == 'true' : false
       formatted
     end
 

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -134,7 +134,7 @@ module GoogleContactsApi
       format_entities('gd$organization')
     end
     def websites
-      format_entities('gd$website')
+      format_entities('gContact$website')
     end
 
     # Return an Array of Hashes representing phone numbers with formatted metadata.

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -85,6 +85,16 @@ module GoogleContactsApi
       self["gd$im"] ? self["gd$im"].map { |i| i.address } : []
     end
 
+    def photo_with_metadata
+      photo_link_entry = self['link'].find { |l| l.rel == 'http://schemas.google.com/contacts/2008/rel#photo' }
+      return nil unless @api && photo_link_entry['gd$etag'] # etag is always specified if actual photo is present
+
+      response = @api.oauth.get(photo_link)
+      if GoogleContactsApi::Api.parse_response_code(response) == 200
+        { etag: photo_link_entry['gd$etag'], content_type: response.headers['content-type'], data: response.body }
+      end
+    end
+
     # Convenience method to return a nested $t field.
     # If the field doesn't exist, return nil
     def nested_t_field_or_nil(level1, level2)

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -110,6 +110,9 @@ module GoogleContactsApi
     def name_suffix
       nested_t_field_or_nil 'gd$name', 'gd$nameSuffix'
     end
+    def birthday
+      self['gContact$birthday'] ? self['gContact$birthday']['when'] : nil
+    end
 
     def relations
       self['gContact$relation'] ? self['gContact$relation'] : []
@@ -121,51 +124,63 @@ module GoogleContactsApi
       spouse_rel['$t'] if spouse_rel
     end
 
-    # Return an Array of Hashes representing addresses with formatted metadata.
     def addresses
-      self['gd$structuredPostalAddress'] ? self['gd$structuredPostalAddress'].map(&method(:format_address)) : []
+      format_entities('gd$structuredPostalAddress', :format_address)
+    end
+    def organizations
+      format_entities('gd$organization')
+    end
+    def websites
+      format_entities('gd$website')
     end
 
     # Return an Array of Hashes representing phone numbers with formatted metadata.
     def phone_numbers_full
-      self["gd$phoneNumber"] ? self["gd$phoneNumber"].map(&method(:format_phone_number)) : []
+      format_entities('gd$phoneNumber', :format_phone_number)
     end
 
     # Return an Array of Hashes representing emails with formatted metadata.
     def emails_full
-      self["gd$email"] ? self["gd$email"].map(&method(:format_email)) : []
+      format_entities('gd$email')
     end
 
   private
-    def format_address(unformatted)
+    # Return an Array of Hashes representing addresses with formatted metadata.
+    def format_entities(key, format_method=:format_entity)
+      self[key] ? self[key].map(&method(format_method)) : []
+    end
+
+    def format_entity(unformatted, default_rel=nil, text_key=nil)
       formatted = {}
-      formatted[:rel] = unformatted['rel'] ? unformatted['rel'].gsub('http://schemas.google.com/g/2005#', '') : 'work'
-      unformatted.delete 'rel'
+
       formatted[:primary] = unformatted['primary'] ? unformatted['primary'] == 'true' : false
       unformatted.delete 'primary'
-      unformatted.each do |key, value|
-        formatted[key.sub('gd$', '').underscore.to_sym] = value['$t']
+
+      if unformatted['rel']
+        formatted[:rel] = unformatted['rel'].gsub('http://schemas.google.com/g/2005#', '')
+        unformatted.delete 'rel'
+      elsif default_rel
+        formatted[:rel] = default_rel
       end
+
+      if text_key
+        formatted[text_key] = unformatted['$t']
+        unformatted.delete '$t'
+      end
+
+      unformatted.each do |key, value|
+        formatted[key.sub('gd$', '').underscore.to_sym] = value['$t'] ? value['$t'] : value
+      end
+
       formatted
     end
 
-    def format_email_or_phone(unformatted)
-      formatted = {}
-      formatted[:primary] = unformatted['primary'] ? unformatted['primary'] == 'true' : false
-      unformatted.delete 'primary'
-      unformatted.each do |key, value|
-        formatted[key.underscore.to_sym] = value ? value.gsub('http://schemas.google.com/g/2005#', '') : value
-      end
-      formatted
+    def format_address(unformatted)
+      return format_entity(unformatted, 'work')
     end
 
     def format_phone_number(unformatted)
-      unformatted[:number] = unformatted['$t']
-      unformatted.delete '$t'
-      format_email_or_phone unformatted
-    end
-    def format_email(unformatted)
-      format_email_or_phone unformatted
+      format_entity unformatted, nil, :number
     end
   end
 end

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -111,7 +111,10 @@ module GoogleContactsApi
       nested_t_field_or_nil 'gd$name', 'gd$nameSuffix'
     end
     def birthday
-      self['gContact$birthday'] ? self['gContact$birthday']['when'] : nil
+      if self['gContact$birthday']
+        day, month, year = self['gContact$birthday']['when'].split('-').reverse
+        { year: year == '' ? nil : year.to_i, month: month.to_i, day: day.to_i }
+      end
     end
 
     def relations

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -289,6 +289,22 @@ describe "GoogleContactsApi" do
       expect(@oauth).to receive("get").with(@contact.photo_link)
       @contact.photo
     end
+    it "should feat a photo with metadata" do
+      @oauth = double("oauth")
+      allow(@oauth).to receive(:get).and_return(Hashie::Mash.new({
+         "body" => "some response",
+         "code" => 200,
+         "headers" => { "content-type" => "image/jpeg" }
+       }))
+      @api = double("api")
+      allow(@api).to receive(:oauth).and_return(@oauth)
+      @contact = GoogleContactsApi::Contact.new(@contact_json_hash, nil, @api)
+      expect(@oauth).to receive("get").with(@contact.photo_link)
+      expect(@contact.photo_with_metadata).to eq( { data: 'some response',
+                                                    etag: '"dxt2DAEZfCp7ImA-AV4zRxBoPG4UK3owXBM."',
+                                                    content_type: 'image/jpeg'
+                                                  } )
+    end
     # TODO: there isn't any phone number in here
     pending "should return all phone numbers"
     it "should return all e-mail addresses" do

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -331,6 +331,9 @@ describe "GoogleContactsApi" do
             'gd$familyName' => { '$t' => 'Doe' },
             'gd$fullName' => { '$t' => 'John Doe' }
           },
+          'gContact$birthday' => {
+            'when' => '1988-05-12'
+          },
           'gContact$relation' => [ { '$t' => 'Jane', 'rel' => 'spouse' } ],
           'gd$structuredPostalAddress' => [
             {
@@ -406,6 +409,14 @@ describe "GoogleContactsApi" do
         expect(@empty.spouse).to be_nil
         expect(@partly_empty.spouse).to be_nil
         expect(@contact_v3.spouse).to eq('Jane')
+      end
+
+      it 'has birthday' do
+        expect(@empty.birthday).to be_nil
+        expect(@contact_v3.birthday).to eq({ year: 1988, month: 5, day: 12 })
+
+        contact_birthday_no_year = GoogleContactsApi::Contact.new('gContact$birthday' => { 'when' => '--05-12' })
+        expect(contact_birthday_no_year.birthday).to eq({ year: nil, month: 5, day: 12 })
       end
       
       it 'has addresses' do

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -365,6 +365,13 @@ describe "GoogleContactsApi" do
               '$t' => '(123) 334-5158',
               'rel' => 'http://schemas.google.com/g/2005#mobile'
             }
+          ],
+          'gd$organization' => [
+            {
+              'gd$orgTitle' => { '$t' => 'Worker Person' },
+              'gd$orgName' => { '$t' => 'Example, Inc' },
+              'rel' => 'http://schemas.google.com/g/2005#other'
+            }
           ]
         )
       end
@@ -436,6 +443,20 @@ describe "GoogleContactsApi" do
       it 'has full emails' do
         expect(@empty.emails_full).to eq([])
         expect(@contact_v3.emails_full).to eq([ { :primary => true, :address => 'johnsmith@example.com', :rel => 'other' } ])
+      end
+
+      it 'has organizations' do
+        expect(@empty.organizations).to eq([])
+
+        formatted_organizations = [
+            {
+                :primary => false,
+                :rel => 'other',
+                :org_title => 'Worker Person',
+                :org_name => 'Example, Inc'
+            }
+        ]
+        expect(@contact_v3.organizations).to eq(formatted_organizations)
       end
     end
   end

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -289,7 +289,7 @@ describe "GoogleContactsApi" do
       expect(@oauth).to receive("get").with(@contact.photo_link)
       @contact.photo
     end
-    it "should feat a photo with metadata" do
+    it "should fetch a photo with metadata" do
       @oauth = double("oauth")
       allow(@oauth).to receive(:get).and_return(Hashie::Mash.new({
          "body" => "some response",
@@ -301,7 +301,7 @@ describe "GoogleContactsApi" do
       @contact = GoogleContactsApi::Contact.new(@contact_json_hash, nil, @api)
       expect(@oauth).to receive("get").with(@contact.photo_link)
       expect(@contact.photo_with_metadata).to eq( { data: 'some response',
-                                                    etag: '"dxt2DAEZfCp7ImA-AV4zRxBoPG4UK3owXBM."',
+                                                    etag: 'dxt2DAEZfCp7ImA-AV4zRxBoPG4UK3owXBM.',
                                                     content_type: 'image/jpeg'
                                                   } )
     end
@@ -366,9 +366,7 @@ describe "GoogleContactsApi" do
               'gd$country' => { '$t' => 'United States of America' },
               'gd$formattedAddress' => { '$t' => "123 Far Ln.\nAnywhere\nMO\n67891\nUnited States of America" },
               'gd$city' => { '$t' => 'Anywhere' },
-              'gd$street' => { '$t' => '123 Far Ln.' },
-              'gd$region' => { '$t' => 'MO' },
-              'gd$postcode' => { '$t' => '67891' }
+              'gd$street' => { '$t' => '123 Far Ln.' }
             }
           ],
           'gd$email' => [
@@ -439,26 +437,10 @@ describe "GoogleContactsApi" do
         expect(@empty.addresses).to eq([])
 
         formatted_addresses = [
-          {
-              :rel => 'work',
-              :primary => false,
-              :country => 'United States of America',
-              :formatted_address => "2345 Long Dr. #232\nSomwhere\nIL\n12345\nUnited States of America",
-              :city => 'Somwhere',
-              :street => '2345 Long Dr. #232',
-              :region => 'IL',
-              :postcode => '12345'
-          },
-          {
-              :rel => 'home',
-              :primary => true,
-              :country => 'United States of America',
-              :formatted_address => "123 Far Ln.\nAnywhere\nMO\n67891\nUnited States of America",
-              :city => 'Anywhere',
-              :street => '123 Far Ln.',
-              :region => 'MO',
-              :postcode => '67891'
-          }
+          { rel: 'work', primary: false, country: 'United States of America', city: 'Somwhere', street: '2345 Long Dr. #232',
+            region: 'IL', postcode: '12345' },
+          { rel: 'home', primary: true, country: 'United States of America', city: 'Anywhere', street: '123 Far Ln.',
+            region: nil, postcode: nil }
         ]
         expect(@contact_v3.addresses).to eq(formatted_addresses)
       end
@@ -476,12 +458,12 @@ describe "GoogleContactsApi" do
         expect(@empty.organizations).to eq([])
 
         formatted_organizations = [
-            {
-                :primary => false,
-                :rel => 'other',
-                :org_title => 'Worker Person',
-                :org_name => 'Example, Inc'
-            }
+          {
+            org_title: 'Worker Person',
+            org_name: 'Example, Inc',
+            primary: false,
+            rel: 'other'
+          }
         ]
         expect(@contact_v3.organizations).to eq(formatted_organizations)
       end

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -343,6 +343,7 @@ describe "GoogleContactsApi" do
             },
             {
               'rel' => 'http://schemas.google.com/g/2005#home',
+              'primary' => 'true',
               'gd$country' => { '$t' => 'United States of America' },
               'gd$formattedAddress' => { '$t' => "123 Far Ln.\nAnywhere\nMO\n67891\nUnited States of America" },
               'gd$city' => { '$t' => 'Anywhere' },
@@ -406,6 +407,7 @@ describe "GoogleContactsApi" do
         formatted_addresses = [
           {
               :rel => 'work',
+              :primary => false,
               :country => 'United States of America',
               :formatted_address => "2345 Long Dr. #232\nSomwhere\nIL\n12345\nUnited States of America",
               :city => 'Somwhere',
@@ -415,6 +417,7 @@ describe "GoogleContactsApi" do
           },
           {
               :rel => 'home',
+              :primary => true,
               :country => 'United States of America',
               :formatted_address => "123 Far Ln.\nAnywhere\nMO\n67891\nUnited States of America",
               :city => 'Anywhere',


### PR DESCRIPTION
This adds the following methods to `Contact`: `photo_with_metadata`, `birthday`, `organizations` and `websites`. It also has a fix for the `addresses` method. I also did a small refactor for formatting the entities for the multi-value fields.