### PR TITLE
Add more fields, handle optional Yomigana in name

### DIFF
--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -22,6 +22,10 @@ module GoogleContactsApi
       _link ? _link.href : nil
     end
 
+    def etag
+      self['gd$etag']
+    end
+
     # Returns link entry for the photo
     def photo_link_entry
       self["link"].find { |l| l.rel == "http://schemas.google.com/contacts/2008/rel#photo" }

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -168,6 +168,23 @@ module GoogleContactsApi
       format_entities('gd$email')
     end
 
+    def group_membership_info
+      if self['gContact$groupMembershipInfo']
+        self['gContact$groupMembershipInfo'].map(&method(:format_group_membership))
+      else
+        []
+      end
+    end
+    def format_group_membership(membership)
+      { deleted: membership['deleted'] == 'true', href: membership['href'] }
+    end
+    def group_memberships
+      group_membership_info.select { |info| !info[:deleted] }.map { |info| info[:href] }
+    end
+    def deleted_group_memberships
+      group_membership_info.select { |info| info[:deleted] }.map { |info| info[:href] }
+    end
+
   private
     def format_entities(key, format_method=:format_entity)
       self[key] ? self[key].map(&method(format_method)) : []

--- a/lib/google_contacts_api/group.rb
+++ b/lib/google_contacts_api/group.rb
@@ -8,6 +8,11 @@ module GoogleContactsApi
       !self["gContact$systemGroup"].nil?
     end
 
+    def system_group_id
+      return unless self.system_group?
+      self['gContact$systemGroup']['id']
+    end
+
     # Return the contacts in this group and cache them.
     def contacts(params = {})
       # contacts in this group

--- a/lib/google_contacts_api/result.rb
+++ b/lib/google_contacts_api/result.rb
@@ -46,7 +46,7 @@ module GoogleContactsApi
     end
     
     def deleted?
-      raise NotImplementedError
+      self.key?('gd$deleted')
     end
     
     def inspect

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -240,7 +240,10 @@ describe "GoogleContactsApi" do
   end
 
   describe "Result" do
-    # no testing, it's just an implementation detail to inherit
+    it 'supports the deleted? method' do
+      expect(GoogleContactsApi::Result.new('gd$deleted' => {}).deleted?).to eq(true)
+      expect(GoogleContactsApi::Result.new.deleted?).to eq(false)
+    end
   end
 
   describe "Contact" do

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -519,15 +519,23 @@ describe "GoogleContactsApi" do
           'rel' => 'http://schemas.google.com/g/2005#other',
           'primary' => 'true',
           'gd$orgName' => {
-            'yomi' => 'Japanese yomigana'
+            'yomi' => 'Yomigana'
           }
         }],
       }
       contact = GoogleContactsApi::Contact.new(contact_params, nil, @api)
+
       expect(contact.given_name).to eq('John')
+      expect(contact.given_name_yomi).to be_nil
+
       expect(contact.additional_name).to eq('Text name')
-      expect(contact.family_name).to eq('Yomi chars only')
-      expect(contact.organizations.first[:org_name]).to eq('Japanese yomigana')
+      expect(contact.additional_name_yomi).to eq('And yomi chars')
+
+      expect(contact.family_name).to be_nil
+      expect(contact.family_name_yomi).to eq('Yomi chars only')
+
+      expect(contact.organizations.first[:org_name]).to be_nil
+      expect(contact.organizations.first[:org_name_yomi]).to eq('Yomigana')
     end
   end
 

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -554,6 +554,14 @@ describe "GoogleContactsApi" do
     it "should tell me if it's a system group" do
       expect(@group).to be_system_group
     end
+    it 'tells the system group id or nil if not a system group' do
+      expect(@group).to be_system_group
+      expect(@group.system_group_id).to eq('Contacts')
+
+      @group.delete('gContact$systemGroup')
+      expect(@group).to_not be_system_group
+      expect(@group.system_group_id).to be_nil
+    end
     describe ".contacts" do
       before(:each) do
         @api = double("api")

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -397,6 +397,16 @@ describe "GoogleContactsApi" do
               'gd$orgName' => { '$t' => 'Example, Inc' },
               'rel' => 'http://schemas.google.com/g/2005#other'
             }
+          ],
+          'gContact$groupMembershipInfo' => [
+            {
+              'deleted' => 'false',
+              'href' => 'http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/111'
+            },
+            {
+              'deleted' => 'true',
+              'href' => 'http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/222'
+            }
           ]
         )
       end
@@ -474,6 +484,24 @@ describe "GoogleContactsApi" do
           }
         ]
         expect(@contact_v3.organizations).to eq(formatted_organizations)
+      end
+
+      it 'has group membership info' do
+        expect(@empty.group_membership_info).to eq([])
+
+        group_membership_info = [
+          { deleted: false, href: 'http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/111' },
+          { deleted: true, href: 'http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/222' }
+        ]
+        expect(@contact_v3.group_membership_info).to eq(group_membership_info)
+      end
+
+      it 'has group memberships' do
+        expect(@contact_v3.group_memberships).to eq(['http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/111'])
+      end
+
+      it 'has deleted group memberships' do
+        expect(@contact_v3.deleted_group_memberships).to eq(['http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/222'])
       end
     end
   end

--- a/spec/google_contacts_api_spec.rb
+++ b/spec/google_contacts_api_spec.rb
@@ -418,13 +418,11 @@ describe "GoogleContactsApi" do
       end
 
       it 'has given_name' do
-        expect(@contact_v3).to receive(:nested_t_field_or_nil).with('gd$name', 'gd$givenName').and_return('val')
-        expect(@contact_v3.given_name).to eq('val')
+        expect(@contact_v3.given_name).to eq('John')
       end
 
       it 'has family_name' do
-        expect(@contact_v3).to receive(:nested_t_field_or_nil).with('gd$name', 'gd$familyName').and_return('val')
-        expect(@contact_v3.family_name).to eq('val')
+        expect(@contact_v3.family_name).to eq('Doe')
       end
 
       it 'has full_name' do
@@ -503,6 +501,30 @@ describe "GoogleContactsApi" do
       it 'has deleted group memberships' do
         expect(@contact_v3.deleted_group_memberships).to eq(['http://www.google.com/m8/feeds/groups/test.user%40gmail.com/base/222'])
       end
+    end
+
+    # The Google Contacts API (https://developers.google.com/gdata/docs/2.0/elements)
+    # specifies an optional yomi field for orgName, givenName, additionalName and familyName
+    it 'handles Japanese yomigana "yomi" name values' do
+      contact_params = {
+        'gd$name' => {
+          'gd$givenName' => {'$t' => 'John' },
+          'gd$additionalName' => {'$t' => 'Text name', 'yomi' => 'And yomi chars' },
+          'gd$familyName' => { 'yomi' => 'Yomi chars only' },
+        },
+        'gd$organization' => [{
+          'rel' => 'http://schemas.google.com/g/2005#other',
+          'primary' => 'true',
+          'gd$orgName' => {
+            'yomi' => 'Japanese yomigana'
+          }
+        }],
+      }
+      contact = GoogleContactsApi::Contact.new(contact_params, nil, @api)
+      expect(contact.given_name).to eq('John')
+      expect(contact.additional_name).to eq('Text name')
+      expect(contact.family_name).to eq('Yomi chars only')
+      expect(contact.organizations.first[:org_name]).to eq('Japanese yomigana')
     end
   end
 


### PR DESCRIPTION
Regarding the optional Japanese Yomigana (search for "yomi" in the [Google Contacts Kinds doc](https://developers.google.com/gdata/docs/2.0/elements)), we encountered Google contacts which had junk data in the optional yomi fields, which then caused a crash in our program because rather than a string, the name methdods would return a hash-like object. 

If someone needs to access the yomigana fields for real Yomigana Japanese reading aid data, they could always access it via the hash syntax for the GoogleContactsApi::Contact instance.

This also adds a variety of other fields / accessors.