### PR TITLE
fetch etag for photo of contact and detect has_photo

### DIFF
--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -42,6 +42,10 @@ module GoogleContactsApi
       photo_link_entry.try(:[], 'gd$etag')
     end
 
+    #
+    # If a contact does not have a photo, then the photo link element has no gd:etag attribute.
+    # https://developers.google.com/google-apps/contacts/v3/#retrieving_a_contacts_photo
+    #
     def has_photo?
       photo_etag != nil
     end

--- a/lib/google_contacts_api/contact.rb
+++ b/lib/google_contacts_api/contact.rb
@@ -38,6 +38,14 @@ module GoogleContactsApi
       _link ? _link.href : nil
     end
 
+    def photo_etag
+      photo_link_entry.try(:[], 'gd$etag')
+    end
+
+    def has_photo?
+      photo_etag != nil
+    end
+
     # Returns binary data for the photo. You can probably
     # use it in a data-uri. This is in PNG format.
     def photo

--- a/spec/lib/google_contacts_api/contact_spec.rb
+++ b/spec/lib/google_contacts_api/contact_spec.rb
@@ -24,6 +24,18 @@ describe GoogleContactsApi::Contact do
     end
   end
 
+  describe "#photo_etag" do
+    it "returns correct photo_etag" do
+      expect(subject.photo_etag).to eq("\"dxt2DAEZfCp7ImA-AV4zRxBoPG4UK3owXBM.\"")
+    end
+  end
+
+  describe "#has_photo?" do
+    it "returns true" do
+      expect(subject.has_photo?).to eq(true)
+    end
+  end
+
   describe "#edit_link" do
     it "returns correct edit_link" do
       expect(subject.edit_link).to eq("https://www.google.com/m8/feeds/contacts/example%40gmail.com/full/0")
@@ -129,7 +141,7 @@ describe GoogleContactsApi::Contact do
 
       @partly_empty = GoogleContactsApi::Contact.new(
         'gd$name' => {},
-        'gContact$relation' => []        
+        'gContact$relation' => []
       )
 
       @contact_v3 = GoogleContactsApi::Contact.new(


### PR DESCRIPTION
Right now we check photo of contact like href.nil?, but by default user has href of photo all time. We can check it by etag: [https://developers.google.com/google-apps/contacts/v3/#retrieving_a_contacts_photo](url)
Could anyone check and merge this update? Thanks!
